### PR TITLE
feat(ui): shadcn 기반 UI 리프레시

### DIFF
--- a/src/components/SelectBox.tsx
+++ b/src/components/SelectBox.tsx
@@ -25,7 +25,7 @@ export const SelectBox = ({ value, onChange }: SelectBoxProps) => {
 
   return (
     <Select value={selectedValue} onValueChange={handleSelectChange}>
-      <SelectTrigger className="w-[180px]">
+      <SelectTrigger className="w-[180px] border-border/70 bg-background/90">
         <SelectValue placeholder="Theme" />
       </SelectTrigger>
       <SelectContent>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,28 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import type { HTMLAttributes } from "react";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors",
+  {
+    variants: {
+      variant: {
+        default: "border-transparent bg-primary text-primary-foreground",
+        secondary: "border-transparent bg-secondary text-secondary-foreground",
+        outline: "border-border text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+export interface BadgeProps extends HTMLAttributes<HTMLDivElement>, VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+export { Badge, badgeVariants };

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,41 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("rounded-2xl border bg-card text-card-foreground shadow-sm", className)} {...props} />
+  )
+);
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => <div ref={ref} className={cn("flex flex-col space-y-1.5 p-5", className)} {...props} />
+);
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3 ref={ref} className={cn("text-lg font-semibold leading-none tracking-tight", className)} {...props} />
+  )
+);
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+  )
+);
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => <div ref={ref} className={cn("p-5 pt-0", className)} {...props} />
+);
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => <div ref={ref} className={cn("flex items-center p-5 pt-0", className)} {...props} />
+);
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle };

--- a/src/layout/Footer.tsx
+++ b/src/layout/Footer.tsx
@@ -1,19 +1,15 @@
 export default function Footer() {
-    return (
-        <footer className="bg-[#8B4513] text-white py-6 wood-texture">
-            <div className="container mx-auto px-4">
-                <div className="flex flex-wrap justify-between items-center">
-                    <div className="w-full md:w-1/3 text-center md:text-left mb-4 md:mb-0">
-                        <h2 className="text-2xl font-bold"></h2>
-                        <p className="mt-2">
-                            책 한권만 읽은 자의 용감한 독후감
-                        </p>
-                    </div>
-                    <div className="w-full md:w-1/3 text-center md:text-right">
-                        <p>&copy; 2025 jingjing2222. All rights reserved.</p>
-                    </div>
-                </div>
-            </div>
-        </footer>
-    );
+  return (
+    <footer className="mt-10 border-t border-border/70 py-8">
+      <div className="page-shell">
+        <div className="panel-surface flex flex-col items-center justify-between gap-3 px-6 py-5 text-center md:flex-row md:text-left">
+          <div>
+            <p className="text-sm font-semibold text-brand-gradient">책 한권만 읽은 자의 용감한 독후감</p>
+            <p className="mt-1 text-xs text-muted-foreground">Read, reflect, and leave one honest line.</p>
+          </div>
+          <p className="text-xs text-muted-foreground">© 2026 jingjing2222. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  );
 }

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -1,88 +1,79 @@
 import { useContext, useEffect, useState } from "react";
 import { Link } from "react-router";
+import { BookOpen, LogOut, PlusCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useCookies } from "react-cookie";
 import { ModalContext } from "@/components/Modal/ModalContext";
 
+const LOGO_IMAGE_URL = `${import.meta.env.BASE_URL}image.png`;
+
 export default function Header() {
   const [cookies, , removeCookie] = useCookies(["username"]);
   const [isAdmin, setIsAdmin] = useState(cookies.username);
-  const [isHovered, setIsHovered] = useState(false);
   const { openModal, setModal } = useContext(ModalContext);
 
   useEffect(() => {
     setIsAdmin(cookies.username);
   }, [cookies.username]);
 
-  const ValidateAdmin = () => {
-    return (
-      <>
-        {isAdmin && (
-          <Link to="/upload">
-            <Button
-              variant="ghost"
-              className="text-white hover:text-[#F4A460] text-sm sm:text-base"
-            >
-              Upload Review
-            </Button>
-          </Link>
-        )}
-        {isAdmin ? (
-          <Button
-            onClick={() => {
-              removeCookie("username", { path: "/" });
-              setIsAdmin(false);
-            }}
-            className="bg-[#D2691E] hover:bg-[#A0522D] text-white text-sm sm:text-base"
-          >
-            Logout
-          </Button>
-        ) : (
-          <div className="flex gap-4">
-            <Button
-              className="bg-[#D2691E] hover:bg-[#A0522D]"
-              onClick={() => {
-                openModal();
-                setModal("login");
-              }}
-            >
-              Login
-            </Button>
-            <Button
-              className="bg-[#D2691E] hover:bg-[#A0522D]"
-              onClick={() => {
-                openModal();
-                setModal("signup");
-              }}
-            >
-              Signup
-            </Button>
-          </div>
-        )}
-      </>
-    );
+  const openAuthModal = (type: "login" | "signup") => {
+    openModal();
+    setModal(type);
   };
 
   return (
-    <header className="bg-[#8B4513] shadow-md wood-texture sticky">
-      <div className="container mx-auto px-4 py-4 flex justify-between items-center">
-        <Link to="/">
-          <img
-            src="https://i.ibb.co/7Ry0jpw/001-2.png"
-            alt="My Personal Book Report"
-            className={`opacity-100 cursor-pointer rounded transition-all w-28 h-auto md:w-40 md:h-auto${
-              isHovered ? "opacity-80" : ""
-            }`}
-            onMouseEnter={() => setIsHovered(true)}
-            onMouseLeave={() => setIsHovered(false)}
-          />
-        </Link>
-        <div className="text-sm md:text-2xl sm:text-lg hidden sm:block">
-          나는 생각한다, 나는 존재한다
+    <header className="sticky top-0 z-20 border-b border-border/70 bg-background/75 backdrop-blur-lg">
+      <div className="page-shell py-4">
+        <div className="panel-surface flex items-center justify-between gap-4 px-4 py-3 md:px-6">
+          <Link to="/" className="group inline-flex items-center gap-3">
+            <img
+              src={LOGO_IMAGE_URL}
+              alt="Rebiewook"
+              className="h-10 w-10 rounded-xl border border-border/60 object-cover shadow-sm transition-transform duration-300 group-hover:scale-105"
+            />
+            <div className="hidden sm:block">
+              <h1 className="text-lg font-bold leading-tight text-brand-gradient">Rebiewook</h1>
+              <p className="text-xs text-muted-foreground">나는 생각한다, 나는 존재한다</p>
+            </div>
+          </Link>
+
+          <nav className="flex items-center gap-2 md:gap-3">
+            <Link to="/" className="hidden sm:block">
+              <Button variant="ghost" className="text-foreground/90">
+                <BookOpen className="mr-1 h-4 w-4" />
+                리뷰 목록
+              </Button>
+            </Link>
+
+            {isAdmin && (
+              <Link to="/upload">
+                <Button variant="secondary" className="border border-border/70">
+                  <PlusCircle className="mr-1 h-4 w-4" />
+                  Upload Review
+                </Button>
+              </Link>
+            )}
+
+            {isAdmin ? (
+              <Button
+                onClick={() => {
+                  removeCookie("username", { path: "/" });
+                  setIsAdmin(false);
+                }}
+              >
+                <LogOut className="mr-1 h-4 w-4" />
+                Logout
+              </Button>
+            ) : (
+              <>
+                <Button variant="outline" onClick={() => openAuthModal("login")}>
+                  Login
+                </Button>
+                <Button onClick={() => openAuthModal("signup")}>Signup</Button>
+              </>
+            )}
+          </nav>
         </div>
-        <nav className="flex flex-col sm:flex-row items-center space-x-4">
-          {<ValidateAdmin />}
-        </nav>
       </div>
     </header>
   );

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -6,11 +6,13 @@ import { ModalProvider } from "@/components/Modal/ModalContext";
 
 export default function Layout() {
   return (
-    <div className="flex flex-col min-h-screen">
+    <div className="flex min-h-screen flex-col">
       <ModalProvider>
         <Header />
-        <main className="flex-grow">
-          <Outlet />
+        <main className="flex-1">
+          <section className="page-shell py-6 md:py-8">
+            <Outlet />
+          </section>
         </main>
         <Footer />
       </ModalProvider>

--- a/src/main.css
+++ b/src/main.css
@@ -3,65 +3,52 @@
 @tailwind utilities;
 
 :root {
-  --background: 30 30% 95%;
-  --foreground: 20 40% 20%;
-  --card: 30 25% 90%;
-  --card-foreground: 20 40% 20%;
-  --popover: 30 25% 90%;
-  --popover-foreground: 20 40% 20%;
-  --primary: 20 60% 40%;
-  --primary-foreground: 30 30% 95%;
-  --secondary: 30 20% 80%;
-  --secondary-foreground: 20 40% 20%;
-  --muted: #27272a;
-  --muted-foreground: 20 30% 30%;
-  --accent: 20 40% 60%;
-  --accent-foreground: 30 30% 95%;
-  --destructive: 0 85% 60%;
-  --destructive-foreground: 30 30% 95%;
-  --border: 20 30% 70%;
-  --input: 20 30% 70%;
-  --ring: 20 60% 40%;
-  --radius: 0.5rem;
-}
-
-body {
-  font-family: "GowunDodum-Regular";
-  @apply bg-background text-foreground;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200' viewBox='0 0 200 200'%3E%3Cfilter id='noise' x='0' y='0'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23noise)' opacity='0.4'/%3E%3C/svg%3E"),
-    linear-gradient(to right, #d2b48c, #deb887);
-  background-repeat: repeat;
-  background-size:
-    200px 200px,
-    100% 100%;
-}
-
-.wood-texture {
-  background-image: repeating-linear-gradient(
-      90deg,
-      rgba(139, 69, 19, 0.1),
-      rgba(139, 69, 19, 0.1) 1px,
-      transparent 1px,
-      transparent 20px
-    ),
-    repeating-linear-gradient(
-      0deg,
-      rgba(139, 69, 19, 0.1),
-      rgba(139, 69, 19, 0.1) 1px,
-      transparent 1px,
-      transparent 20px
-    ),
-    linear-gradient(45deg, #d2b48c, #deb887);
-}
-
-.book-spine {
-  background: linear-gradient(90deg, #cd853f, #deb887);
-  border-left: 2px solid rgba(139, 69, 19, 0.5);
-  border-right: 2px solid rgba(139, 69, 19, 0.5);
+  --background: 32 56% 96%;
+  --foreground: 24 20% 16%;
+  --card: 0 0% 100%;
+  --card-foreground: 24 20% 16%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 24 20% 16%;
+  --primary: 25 72% 38%;
+  --primary-foreground: 48 100% 98%;
+  --secondary: 33 45% 90%;
+  --secondary-foreground: 24 24% 22%;
+  --muted: 34 35% 90%;
+  --muted-foreground: 24 12% 38%;
+  --accent: 35 68% 78%;
+  --accent-foreground: 24 28% 18%;
+  --destructive: 0 76% 52%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 30 28% 84%;
+  --input: 30 28% 84%;
+  --ring: 25 72% 38%;
+  --radius: 0.85rem;
 }
 
 @font-face {
-  font-family: "GowunDodum-Regular";
-  font-weight: normal;
-  src: url("/src/font/Title_Medium.otf") format("truetype");
+  font-family: "Title-Medium";
+  font-style: normal;
+  font-weight: 500;
+  src: url("./font/Title_Medium.otf") format("opentype");
+}
+
+body {
+  font-family: "Title-Medium", "Pretendard", system-ui, -apple-system, sans-serif;
+  @apply bg-background text-foreground antialiased;
+  background-image:
+    radial-gradient(circle at 8% 8%, rgba(255, 255, 255, 0.7) 0%, transparent 45%),
+    radial-gradient(circle at 92% 12%, rgba(255, 255, 255, 0.55) 0%, transparent 35%),
+    linear-gradient(120deg, #f4e9d8 0%, #f7efe3 45%, #f0dfc4 100%);
+}
+
+.page-shell {
+  @apply mx-auto w-full max-w-7xl px-4 md:px-6;
+}
+
+.panel-surface {
+  @apply rounded-3xl border border-border/80 bg-card/90 shadow-lg backdrop-blur-sm;
+}
+
+.text-brand-gradient {
+  @apply bg-gradient-to-r from-amber-700 via-orange-700 to-yellow-700 bg-clip-text text-transparent;
 }

--- a/src/pages/ReviewListPage.tsx
+++ b/src/pages/ReviewListPage.tsx
@@ -1,10 +1,13 @@
-import { BookCard } from "@/pages/home/BookCard";
+import { BookOpenText, ChevronLeft, ChevronRight, Sparkles } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
-import { Skeleton } from "@/components/ui/skeleton";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useSearchParams } from "react-router";
-import { SelectBox } from "@/components/SelectBox";
 import { getReviews } from "@/api/api";
+import { SelectBox } from "@/components/SelectBox";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { BookCard } from "@/pages/home/BookCard";
 
 export interface ReviewListDTO {
   author: string;
@@ -24,19 +27,13 @@ const selectList = [
 export default function ReviewListPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [order, setOrder] = useState(selectList[0].value);
-  const currentPage = parseInt(searchParams.get("page") || "0");
+  const currentPage = Number.parseInt(searchParams.get("page") || "0", 10);
 
   const { status, data } = useQuery({
     queryKey: ["fetchReviews", currentPage, order],
-    queryFn: () => {
-      return getReviews(currentPage, order);
-    },
+    queryFn: () => getReviews(currentPage, order),
     staleTime: 1000 * 20,
   });
-
-  useEffect(() => {
-    console.log(data);
-  }, [data]);
 
   const handleSelectChange = (value: string) => {
     setOrder(value);
@@ -54,71 +51,58 @@ export default function ReviewListPage() {
   };
 
   return (
-    <div className="container mx-auto px-4 py-2">
-      {/* Header Section with Title and SelectBox */}
-      <div className="flex justify-end items-start sm:items-center gap-4 mb-6">
-        {/* SelectBox Container */}
-        <div className="flex flex-col items-end gap-2">
-          <label className="text-sm text-gray-500 font-medium">Sort by</label>
-          <div className="min-w-[140px]">
+    <div className="space-y-6">
+      <Card className="panel-surface border-none">
+        <CardHeader className="flex flex-col gap-4 pb-0 md:flex-row md:items-center md:justify-between">
+          <div>
+            <CardTitle className="flex items-center gap-2 text-2xl md:text-3xl">
+              <BookOpenText className="h-6 w-6 text-primary" />
+              Review Library
+            </CardTitle>
+            <p className="mt-2 text-sm text-muted-foreground">책을 읽고 남긴 생각을 카드 형식으로 모아봤어요.</p>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Sparkles className="h-4 w-4 text-primary" />
             <SelectBox value={selectList} onChange={handleSelectChange} />
           </div>
-        </div>
-      </div>
+        </CardHeader>
 
-      {status === "error" ? (
-        <div className="flex items-center justify-center py-20">
-          <div className="text-center">
-            <div className="text-red-500 text-xl mb-2">⚠️</div>
-            <p className="text-red-600 font-medium">Error fetching data</p>
-            <p className="text-gray-500 text-sm mt-1">Please try again later</p>
-          </div>
-        </div>
-      ) : (
-        <>
-          {/* Books Grid */}
-          <div className="bg-gradient-to-r from-yellow-800 to-yellow-700 shadow-lg rounded-3xl p-5 mb-10 relative overflow-hidden">
-            <div className="absolute inset-0 bg-gradient-to-b from-yellow-900/20 via-transparent to-yellow-900/20 pointer-events-none"></div>
-            <div className="relative z-10">
-              <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-6">
-                {status === "pending"
-                  ? Array.from({ length: 10 }, (_, index) => (
-                      <Skeleton
-                        key={index}
-                        className="w-full h-96 rounded-2xl"
-                      />
-                    ))
-                  : data?.data.map((review: ReviewListDTO) => (
-                      <BookCard key={review.id} review={review} />
-                    ))}
+        <CardContent className="pt-6">
+          {status === "error" ? (
+            <div className="flex min-h-[300px] items-center justify-center rounded-2xl border border-dashed border-destructive/40 bg-destructive/5 p-6 text-center">
+              <div>
+                <p className="text-base font-semibold text-destructive">리뷰를 불러오지 못했어요.</p>
+                <p className="mt-1 text-sm text-muted-foreground">잠시 후 다시 시도해 주세요.</p>
               </div>
             </div>
-          </div>
+          ) : (
+            <>
+              <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                {status === "pending"
+                  ? Array.from({ length: 8 }, (_, index) => <Skeleton key={index} className="h-[420px] rounded-2xl" />)
+                  : data?.data.map((review: ReviewListDTO) => <BookCard key={review.id} review={review} />)}
+              </div>
 
-          {/* Pagination */}
-          <div className="flex justify-center items-center gap-4 mt-8">
-            <button
-              onClick={handlePrevPage}
-              disabled={currentPage === 0}
-              className="px-6 py-3 bg-gradient-to-r from-yellow-800 to-yellow-700 text-white font-semibold rounded-full shadow-lg hover:from-yellow-700 hover:to-yellow-600 disabled:from-gray-400 disabled:to-gray-300 disabled:cursor-not-allowed transition-all duration-300 transform hover:scale-105 disabled:hover:scale-100"
-            >
-              Previous
-            </button>
+              <div className="mt-8 flex items-center justify-center gap-3">
+                <Button variant="outline" onClick={handlePrevPage} disabled={currentPage === 0}>
+                  <ChevronLeft className="mr-1 h-4 w-4" />
+                  Previous
+                </Button>
 
-            <span className="px-4 py-2 bg-white/90 text-[#4B3621] font-medium rounded-full shadow-md">
-              Page {currentPage + 1}
-            </span>
+                <div className="rounded-full border border-border bg-background px-4 py-2 text-sm text-muted-foreground">
+                  Page <span className="font-semibold text-foreground">{currentPage + 1}</span>
+                </div>
 
-            <button
-              onClick={handleNextPage}
-              disabled={!data?.pagination.hasNextPage}
-              className="px-6 py-3 bg-gradient-to-r from-yellow-800 to-yellow-700 text-white font-semibold rounded-full shadow-lg hover:from-yellow-700 hover:to-yellow-600 disabled:from-gray-400 disabled:to-gray-300 disabled:cursor-not-allowed transition-all duration-300 transform hover:scale-105 disabled:hover:scale-100"
-            >
-              Next
-            </button>
-          </div>
-        </>
-      )}
+                <Button variant="outline" onClick={handleNextPage} disabled={!data?.pagination.hasNextPage}>
+                  Next
+                  <ChevronRight className="ml-1 h-4 w-4" />
+                </Button>
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/src/pages/home/BookCard.tsx
+++ b/src/pages/home/BookCard.tsx
@@ -1,31 +1,35 @@
 import { Link } from "react-router";
+import { CalendarDays } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
 import { ReviewListDTO } from "@/pages/ReviewListPage";
 
 export const BookCard = ({ review }: { review: ReviewListDTO }) => {
   return (
-    <Link to={`/bookdetailes/${review.id}`}>
-      <div className="flex flex-col bg-white rounded-2xl md:rounded-3xl shadow-md overflow-hidden transition-transform duration-300 ease-in-out hover:scale-105 h-full">
-        <div className="relative w-full flex-[6]">
+    <Link to={`/bookdetailes/${review.id}`} className="group block h-full">
+      <Card className="h-full overflow-hidden border-border/70 bg-card/95 transition-all duration-300 group-hover:-translate-y-1 group-hover:shadow-xl">
+        <div className="relative aspect-[4/5] overflow-hidden bg-secondary/50">
           <img
-            src={review.cover_image || "/placeholder.svg"}
+            src={review.cover_image || `${import.meta.env.BASE_URL}image-1.png`}
             alt={`Cover of ${review.title}`}
-            className="object-cover w-11/12 h-full my-1 ml-1.5 md:ml-2.5 md:mt-2 rounded-lg"
+            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
           />
-        </div>
-        <div className="flex-[2] p-2 md:p-4 flex flex-col justify-between">
-          <div className="flex-1">
-            <h2 className="text-md font-semibold mb-2 line-clamp-2">
-              {review.title}
-            </h2>
-            <p className="text-gray-600 mb-2 text-sm line-clamp-3 flex-1">
-              {review.description}
-            </p>
+          <div className="absolute right-3 top-3">
+            <Badge variant="secondary" className="shadow-sm">
+              Review
+            </Badge>
           </div>
-          <p className="text-sm text-gray-500 mt-auto">
-            {review.published_date}
-          </p>
         </div>
-      </div>
+
+        <CardContent className="space-y-3 p-4">
+          <h2 className="line-clamp-2 text-base font-semibold leading-snug text-foreground md:text-lg">{review.title}</h2>
+          <p className="line-clamp-3 text-sm text-muted-foreground">{review.description}</p>
+          <div className="flex items-center gap-1 text-xs text-muted-foreground">
+            <CalendarDays className="h-3.5 w-3.5" />
+            <span>{review.published_date}</span>
+          </div>
+        </CardContent>
+      </Card>
     </Link>
   );
 };


### PR DESCRIPTION
## 요약
- Next.js 전환 없이 기존 React(Vite) 코드베이스에서 UI만 리팩토링
- shadcn 스타일의 디자인 시스템 컴포넌트(`card`, `badge`) 추가
- Header/Footer/Layout/ReviewList/BookCard 톤앤매너 통일
- GitHub Pages 서브패스(`/Rebiewook`) 전제 유지

## 포함 내용
- `src/components/ui/card.tsx` 추가
- `src/components/ui/badge.tsx` 추가
- `src/main.css` 디자인 토큰/레이아웃 유틸 정리
- `Header`, `Footer`, `Layout`, `ReviewListPage`, `BookCard`, `SelectBox` UI 개선

## 제외(요청 준수)
- DB 스키마 변경 없음
- 성능 최적화 목적 변경 없음 (UI 개선 중심)

## 검증
- `corepack pnpm lint` (warnings only, errors 0)
- `corepack pnpm exec tsc --noEmit` 통과
- `corepack pnpm build` 통과

## 메모
- 기존 Supabase/API 연동 구조는 유지
